### PR TITLE
Introduce useDApp 

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,1 +1,2 @@
-export const nftContractAddress = '0x471bf0e778645CCaF093d17c1DF1aD8363C45C54'
+export const nftContractAddress = "0x471bf0e778645CCaF093d17c1DF1aD8363C45C54";
+export const INFURA_ID = "3ee178f96e63405181f410fe91325b3b";

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
       },
       "devDependencies": {
         "eslint": "8.9.0",
-        "eslint-config-next": "12.1.0"
+        "eslint-config-next": "12.1.0",
+        "prettier": "^2.5.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7841,6 +7842,18 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -15020,6 +15033,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true
     },
     "pretty-hrtime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@mdi/js": "^6.5.95",
         "@mdi/react": "^1.5.0",
         "@svgr/webpack": "^6.2.1",
+        "@usedapp/core": "^0.7.3",
         "autoprefixer": "^10.4.2",
         "axios": "^0.26.0",
         "babel-plugin-macros": "^3.1.0",
@@ -3329,8 +3330,7 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
-      "peer": true
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "node_modules/@types/react": {
       "version": "17.0.39",
@@ -3462,6 +3462,242 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@uniswap/token-lists": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@uniswap/token-lists/-/token-lists-1.0.0-beta.27.tgz",
+      "integrity": "sha512-x5hmIniQ9TGqOBCRqfWcmZi/U5kB0qrHMDQ9igs3nMbK0wwmYLraL4owbIwXFGR/co6/lJYJC4K/Gjn4wZY5mQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@usedapp/core": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@usedapp/core/-/core-0.7.3.tgz",
+      "integrity": "sha512-0Jaidc5E62YdkH4GUKio6Z9cP9ZK81OTgra7UAREMGHhqYuT18EVtvUbDezHqf1jDnYB5E+hZ/J2o17XLOo63w==",
+      "dependencies": {
+        "@types/react": "17.0.1",
+        "@uniswap/token-lists": "^1.0.0-beta.27",
+        "@web3-react/core": "6.1.1",
+        "@web3-react/injected-connector": "6.0.7",
+        "@web3-react/network-connector": "6.1.5",
+        "ethers": "5.5.1",
+        "lodash.merge": "^4.6.2",
+        "nanoid": "3.1.22"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@usedapp/core/node_modules/@ethersproject/networks": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.0.tgz",
+      "integrity": "sha512-KWfP3xOnJeF89Uf/FCJdV1a2aDJe5XTN2N52p4fcQ34QhDqQFkgQKZ39VGtiqUgHcLI8DfT0l9azC3KFTunqtA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/logger": "^5.5.0"
+      }
+    },
+    "node_modules/@usedapp/core/node_modules/@ethersproject/providers": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.5.0.tgz",
+      "integrity": "sha512-xqMbDnS/FPy+J/9mBLKddzyLLAQFjrVff5g00efqxPzcAwXiR+SiCGVy6eJ5iAIirBOATjx7QLhDNPGV+AEQsw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.5.0",
+        "@ethersproject/abstract-signer": "^5.5.0",
+        "@ethersproject/address": "^5.5.0",
+        "@ethersproject/basex": "^5.5.0",
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/constants": "^5.5.0",
+        "@ethersproject/hash": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/networks": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/random": "^5.5.0",
+        "@ethersproject/rlp": "^5.5.0",
+        "@ethersproject/sha2": "^5.5.0",
+        "@ethersproject/strings": "^5.5.0",
+        "@ethersproject/transactions": "^5.5.0",
+        "@ethersproject/web": "^5.5.0",
+        "bech32": "1.1.4",
+        "ws": "7.4.6"
+      }
+    },
+    "node_modules/@usedapp/core/node_modules/@ethersproject/random": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.5.0.tgz",
+      "integrity": "sha512-egGYZwZ/YIFKMHcoBUo8t3a8Hb/TKYX8BCBoLjudVCZh892welR3jOxgOmb48xznc9bTcMm7Tpwc1gHC1PFNFQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0"
+      }
+    },
+    "node_modules/@usedapp/core/node_modules/@ethersproject/web": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.0.tgz",
+      "integrity": "sha512-BEgY0eL5oH4mAo37TNYVrFeHsIXLRxggCRG/ksRIxI2X5uj5IsjGmcNiRN/VirQOlBxcUhCgHhaDLG4m6XAVoA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/base64": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/strings": "^5.5.0"
+      }
+    },
+    "node_modules/@usedapp/core/node_modules/@types/react": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.1.tgz",
+      "integrity": "sha512-w8t9f53B2ei4jeOqf/gxtc2Sswnc3LBK5s0DyJcg5xd10tMHXts2N31cKjWfH9IC/JvEPa/YF1U4YeP1t4R6HQ==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@usedapp/core/node_modules/ethers": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.5.1.tgz",
+      "integrity": "sha512-RodEvUFZI+EmFcE6bwkuJqpCYHazdzeR1nMzg+YWQSmQEsNtfl1KHGfp/FWZYl48bI/g7cgBeP2IlPthjiVngw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "5.5.0",
+        "@ethersproject/abstract-provider": "5.5.1",
+        "@ethersproject/abstract-signer": "5.5.0",
+        "@ethersproject/address": "5.5.0",
+        "@ethersproject/base64": "5.5.0",
+        "@ethersproject/basex": "5.5.0",
+        "@ethersproject/bignumber": "5.5.0",
+        "@ethersproject/bytes": "5.5.0",
+        "@ethersproject/constants": "5.5.0",
+        "@ethersproject/contracts": "5.5.0",
+        "@ethersproject/hash": "5.5.0",
+        "@ethersproject/hdnode": "5.5.0",
+        "@ethersproject/json-wallets": "5.5.0",
+        "@ethersproject/keccak256": "5.5.0",
+        "@ethersproject/logger": "5.5.0",
+        "@ethersproject/networks": "5.5.0",
+        "@ethersproject/pbkdf2": "5.5.0",
+        "@ethersproject/properties": "5.5.0",
+        "@ethersproject/providers": "5.5.0",
+        "@ethersproject/random": "5.5.0",
+        "@ethersproject/rlp": "5.5.0",
+        "@ethersproject/sha2": "5.5.0",
+        "@ethersproject/signing-key": "5.5.0",
+        "@ethersproject/solidity": "5.5.0",
+        "@ethersproject/strings": "5.5.0",
+        "@ethersproject/transactions": "5.5.0",
+        "@ethersproject/units": "5.5.0",
+        "@ethersproject/wallet": "5.5.0",
+        "@ethersproject/web": "5.5.0",
+        "@ethersproject/wordlists": "5.5.0"
+      }
+    },
+    "node_modules/@usedapp/core/node_modules/nanoid": {
+      "version": "3.1.22",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
+      "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/@web3-react/abstract-connector": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@web3-react/abstract-connector/-/abstract-connector-6.0.7.tgz",
+      "integrity": "sha512-RhQasA4Ox8CxUC0OENc1AJJm8UTybu/oOCM61Zjg6y0iF7Z0sqv1Ai1VdhC33hrQpA8qSBgoXN9PaP8jKmtdqg==",
+      "dependencies": {
+        "@web3-react/types": "^6.0.7"
+      }
+    },
+    "node_modules/@web3-react/core": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@web3-react/core/-/core-6.1.1.tgz",
+      "integrity": "sha512-HKXOgPNCmFvrVsed+aW/HlVhwzs8t3b+nzg3BoxgJQo/5yLiJXSumHRBdUrPxhBQiHkHRZiVPAvzf/8JMnm74Q==",
+      "dependencies": {
+        "@ethersproject/keccak256": "^5.0.0-beta.130",
+        "@web3-react/abstract-connector": "^6.0.7",
+        "@web3-react/types": "^6.0.7",
+        "tiny-invariant": "^1.0.6",
+        "tiny-warning": "^1.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@web3-react/injected-connector": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@web3-react/injected-connector/-/injected-connector-6.0.7.tgz",
+      "integrity": "sha512-Y7aJSz6pg+MWKtvdyuqyy6LWuH+4Tqtph1LWfiyVms9II9ar/9B/de4R8wh4wjg91wmHkU+D75yP09E/Soh2RA==",
+      "dependencies": {
+        "@web3-react/abstract-connector": "^6.0.7",
+        "@web3-react/types": "^6.0.7",
+        "tiny-warning": "^1.0.3"
+      }
+    },
+    "node_modules/@web3-react/network-connector": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@web3-react/network-connector/-/network-connector-6.1.5.tgz",
+      "integrity": "sha512-Uwk8iMG8YCnTeKmyXt3Q7QJN28qTs0YTTW8/aes2R26KmYWCk3GdL2eal0QcXUixJy/IjrhXzbwzHgpneJqrWg==",
+      "dependencies": {
+        "@web3-react/abstract-connector": "^6.0.7",
+        "@web3-react/types": "^6.0.7",
+        "tiny-invariant": "^1.0.6"
+      }
+    },
+    "node_modules/@web3-react/types": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@web3-react/types/-/types-6.0.7.tgz",
+      "integrity": "sha512-ofGmfDhxmNT1/P/MgVa8IKSkCStFiyvXe+U5tyZurKdrtTDFU+wJ/LxClPDtFerWpczNFPUSrKcuhfPX1sI6+A=="
     },
     "node_modules/acorn": {
       "version": "8.7.0",
@@ -8953,6 +9189,16 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
+      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
+    },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "node_modules/tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -11797,8 +12043,7 @@
     "@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
-      "peer": true
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "@types/react": {
       "version": "17.0.39",
@@ -11882,6 +12127,179 @@
         "@typescript-eslint/types": "5.12.0",
         "eslint-visitor-keys": "^3.0.0"
       }
+    },
+    "@uniswap/token-lists": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@uniswap/token-lists/-/token-lists-1.0.0-beta.27.tgz",
+      "integrity": "sha512-x5hmIniQ9TGqOBCRqfWcmZi/U5kB0qrHMDQ9igs3nMbK0wwmYLraL4owbIwXFGR/co6/lJYJC4K/Gjn4wZY5mQ=="
+    },
+    "@usedapp/core": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@usedapp/core/-/core-0.7.3.tgz",
+      "integrity": "sha512-0Jaidc5E62YdkH4GUKio6Z9cP9ZK81OTgra7UAREMGHhqYuT18EVtvUbDezHqf1jDnYB5E+hZ/J2o17XLOo63w==",
+      "requires": {
+        "@types/react": "17.0.1",
+        "@uniswap/token-lists": "^1.0.0-beta.27",
+        "@web3-react/core": "6.1.1",
+        "@web3-react/injected-connector": "6.0.7",
+        "@web3-react/network-connector": "6.1.5",
+        "ethers": "5.5.1",
+        "lodash.merge": "^4.6.2",
+        "nanoid": "3.1.22"
+      },
+      "dependencies": {
+        "@ethersproject/networks": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.0.tgz",
+          "integrity": "sha512-KWfP3xOnJeF89Uf/FCJdV1a2aDJe5XTN2N52p4fcQ34QhDqQFkgQKZ39VGtiqUgHcLI8DfT0l9azC3KFTunqtA==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/providers": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.5.0.tgz",
+          "integrity": "sha512-xqMbDnS/FPy+J/9mBLKddzyLLAQFjrVff5g00efqxPzcAwXiR+SiCGVy6eJ5iAIirBOATjx7QLhDNPGV+AEQsw==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.5.0",
+            "@ethersproject/abstract-signer": "^5.5.0",
+            "@ethersproject/address": "^5.5.0",
+            "@ethersproject/basex": "^5.5.0",
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/constants": "^5.5.0",
+            "@ethersproject/hash": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/networks": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/random": "^5.5.0",
+            "@ethersproject/rlp": "^5.5.0",
+            "@ethersproject/sha2": "^5.5.0",
+            "@ethersproject/strings": "^5.5.0",
+            "@ethersproject/transactions": "^5.5.0",
+            "@ethersproject/web": "^5.5.0",
+            "bech32": "1.1.4",
+            "ws": "7.4.6"
+          }
+        },
+        "@ethersproject/random": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.5.0.tgz",
+          "integrity": "sha512-egGYZwZ/YIFKMHcoBUo8t3a8Hb/TKYX8BCBoLjudVCZh892welR3jOxgOmb48xznc9bTcMm7Tpwc1gHC1PFNFQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.0.tgz",
+          "integrity": "sha512-BEgY0eL5oH4mAo37TNYVrFeHsIXLRxggCRG/ksRIxI2X5uj5IsjGmcNiRN/VirQOlBxcUhCgHhaDLG4m6XAVoA==",
+          "requires": {
+            "@ethersproject/base64": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/strings": "^5.5.0"
+          }
+        },
+        "@types/react": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.1.tgz",
+          "integrity": "sha512-w8t9f53B2ei4jeOqf/gxtc2Sswnc3LBK5s0DyJcg5xd10tMHXts2N31cKjWfH9IC/JvEPa/YF1U4YeP1t4R6HQ==",
+          "requires": {
+            "@types/prop-types": "*",
+            "csstype": "^3.0.2"
+          }
+        },
+        "ethers": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.5.1.tgz",
+          "integrity": "sha512-RodEvUFZI+EmFcE6bwkuJqpCYHazdzeR1nMzg+YWQSmQEsNtfl1KHGfp/FWZYl48bI/g7cgBeP2IlPthjiVngw==",
+          "requires": {
+            "@ethersproject/abi": "5.5.0",
+            "@ethersproject/abstract-provider": "5.5.1",
+            "@ethersproject/abstract-signer": "5.5.0",
+            "@ethersproject/address": "5.5.0",
+            "@ethersproject/base64": "5.5.0",
+            "@ethersproject/basex": "5.5.0",
+            "@ethersproject/bignumber": "5.5.0",
+            "@ethersproject/bytes": "5.5.0",
+            "@ethersproject/constants": "5.5.0",
+            "@ethersproject/contracts": "5.5.0",
+            "@ethersproject/hash": "5.5.0",
+            "@ethersproject/hdnode": "5.5.0",
+            "@ethersproject/json-wallets": "5.5.0",
+            "@ethersproject/keccak256": "5.5.0",
+            "@ethersproject/logger": "5.5.0",
+            "@ethersproject/networks": "5.5.0",
+            "@ethersproject/pbkdf2": "5.5.0",
+            "@ethersproject/properties": "5.5.0",
+            "@ethersproject/providers": "5.5.0",
+            "@ethersproject/random": "5.5.0",
+            "@ethersproject/rlp": "5.5.0",
+            "@ethersproject/sha2": "5.5.0",
+            "@ethersproject/signing-key": "5.5.0",
+            "@ethersproject/solidity": "5.5.0",
+            "@ethersproject/strings": "5.5.0",
+            "@ethersproject/transactions": "5.5.0",
+            "@ethersproject/units": "5.5.0",
+            "@ethersproject/wallet": "5.5.0",
+            "@ethersproject/web": "5.5.0",
+            "@ethersproject/wordlists": "5.5.0"
+          }
+        },
+        "nanoid": {
+          "version": "3.1.22",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
+          "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ=="
+        }
+      }
+    },
+    "@web3-react/abstract-connector": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@web3-react/abstract-connector/-/abstract-connector-6.0.7.tgz",
+      "integrity": "sha512-RhQasA4Ox8CxUC0OENc1AJJm8UTybu/oOCM61Zjg6y0iF7Z0sqv1Ai1VdhC33hrQpA8qSBgoXN9PaP8jKmtdqg==",
+      "requires": {
+        "@web3-react/types": "^6.0.7"
+      }
+    },
+    "@web3-react/core": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@web3-react/core/-/core-6.1.1.tgz",
+      "integrity": "sha512-HKXOgPNCmFvrVsed+aW/HlVhwzs8t3b+nzg3BoxgJQo/5yLiJXSumHRBdUrPxhBQiHkHRZiVPAvzf/8JMnm74Q==",
+      "requires": {
+        "@ethersproject/keccak256": "^5.0.0-beta.130",
+        "@web3-react/abstract-connector": "^6.0.7",
+        "@web3-react/types": "^6.0.7",
+        "tiny-invariant": "^1.0.6",
+        "tiny-warning": "^1.0.3"
+      }
+    },
+    "@web3-react/injected-connector": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@web3-react/injected-connector/-/injected-connector-6.0.7.tgz",
+      "integrity": "sha512-Y7aJSz6pg+MWKtvdyuqyy6LWuH+4Tqtph1LWfiyVms9II9ar/9B/de4R8wh4wjg91wmHkU+D75yP09E/Soh2RA==",
+      "requires": {
+        "@web3-react/abstract-connector": "^6.0.7",
+        "@web3-react/types": "^6.0.7",
+        "tiny-warning": "^1.0.3"
+      }
+    },
+    "@web3-react/network-connector": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@web3-react/network-connector/-/network-connector-6.1.5.tgz",
+      "integrity": "sha512-Uwk8iMG8YCnTeKmyXt3Q7QJN28qTs0YTTW8/aes2R26KmYWCk3GdL2eal0QcXUixJy/IjrhXzbwzHgpneJqrWg==",
+      "requires": {
+        "@web3-react/abstract-connector": "^6.0.7",
+        "@web3-react/types": "^6.0.7",
+        "tiny-invariant": "^1.0.6"
+      }
+    },
+    "@web3-react/types": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@web3-react/types/-/types-6.0.7.tgz",
+      "integrity": "sha512-ofGmfDhxmNT1/P/MgVa8IKSkCStFiyvXe+U5tyZurKdrtTDFU+wJ/LxClPDtFerWpczNFPUSrKcuhfPX1sI6+A=="
     },
     "acorn": {
       "version": "8.7.0",
@@ -15880,6 +16298,16 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
+    },
+    "tiny-invariant": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
+      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "tmp": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@mdi/js": "^6.5.95",
     "@mdi/react": "^1.5.0",
     "@svgr/webpack": "^6.2.1",
+    "@usedapp/core": "^0.7.3",
     "autoprefixer": "^10.4.2",
     "axios": "^0.26.0",
     "babel-plugin-macros": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "eslint": "8.9.0",
-    "eslint-config-next": "12.1.0"
+    "eslint-config-next": "12.1.0",
+    "prettier": "^2.5.1"
   }
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,12 +1,24 @@
-import GlobalStyles from '../styles/GlobalStyles'
+import GlobalStyles from "../styles/GlobalStyles";
+import { INFURA_ID } from "../config";
+import { ChainId, DAppProvider } from "@usedapp/core";
+
+const config = {
+  // TODO switch to mainnet
+  readOnlyChainId: ChainId.Rinkeby,
+  readOnlyUrls: {
+    [ChainId.Mainnet]: `https://mainnet.infura.io/v3/${INFURA_ID}`,
+    [ChainId.Rinkeby]: `https://rinkeby.infura.io/v3/${INFURA_ID}`,
+    [ChainId.Ropsten]: `https://ropsten.infura.io/v3/${INFURA_ID}`,
+  },
+};
 
 const App = ({ Component, pageProps }) => {
   return (
-    <>
+    <DAppProvider config={config}>
       <GlobalStyles />
       <Component {...pageProps} />
-    </>
-  )
-}
+    </DAppProvider>
+  );
+};
 
-export default App
+export default App;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,126 +1,123 @@
-import Head from 'next/head'
-import { useState, useEffect } from 'react'
-import { nftContractAddress } from '../config'
-import { ethers } from 'ethers'
-import { abi } from '../utils/abi'
-import tw from 'twin.macro'
-import fetch from 'isomorphic-unfetch'
-import axios from 'axios'
-import { Markdown } from '../components/Markdown'
-import { Button } from '../components/Button'
+import Head from "next/head";
+import { useState, useEffect } from "react";
+import { nftContractAddress } from "../config";
+import { ethers } from "ethers";
+import { abi } from "../utils/abi";
+import tw from "twin.macro";
+import fetch from "isomorphic-unfetch";
+import axios from "axios";
+import { Markdown } from "../components/Markdown";
+import { Button } from "../components/Button";
 
-const Container = tw.div`mt-16 w-full tracking-wide leading-relaxed max-w-screen-lg mx-auto px-8 text-justify`
-const SignContainer = tw.div`w-full flex justify-center mt-10 mb-20`
+const Container = tw.div`mt-16 w-full tracking-wide leading-relaxed max-w-screen-lg mx-auto px-8 text-justify`;
+const SignContainer = tw.div`w-full flex justify-center mt-10 mb-20`;
+const SIGNER_AMOUNT_TO_DISPLAY = 10;
+// TODO switch to mainnet
+const infura = "https://rinkeby.infura.io/v3/3ee178f96e63405181f410fe91325b3b";
+const provider = new ethers.providers.JsonRpcProvider(infura);
 
-const Home = ({data}) => {
-  const [mintedNFT, setMintedNFT] = useState(null)
-  const [miningStatus, setMiningStatus] = useState(null)
-  const [loadingState, setLoadingState] = useState(0)
-  const [txError, setTxError] = useState(null)
-  const [currentAccount, setCurrentAccount] = useState('')
-  const [correctNetwork, setCorrectNetwork] = useState(false)
+const Home = ({ data }) => {
+  const [mintedNFT, setMintedNFT] = useState(null);
+  const [miningStatus, setMiningStatus] = useState(null);
+  const [loadingState, setLoadingState] = useState(0);
+  const [txError, setTxError] = useState(null);
+  const [currentAccount, setCurrentAccount] = useState("");
+  const [correctNetwork, setCorrectNetwork] = useState(false);
   const [signerList, setSignerList] = useState([]);
   const [signerListWithENS, setSignerListWithENS] = useState([]);
-  const SIGNER_AMOUNT_TO_DISPLAY = 10;
+
+  // TODO put as a demo. Remove this one.
+  // console.log(signerList, signerListWithENS);
 
   // Checks if wallet is connected
   const checkIfWalletIsConnected = async () => {
-    const { ethereum } = window
+    const { ethereum } = window;
     if (ethereum) {
-      console.log('Got the ethereum obejct: ', ethereum)
+      console.log("Got the ethereum obejct: ", ethereum);
     } else {
-      console.log('No Wallet found. Connect Wallet')
+      console.log("No Wallet found. Connect Wallet");
     }
 
-    const accounts = await ethereum.request({ method: 'eth_accounts' })
+    const accounts = await provider.send("eth_accounts");
 
     if (accounts.length !== 0) {
-      console.log('Found authorized Account: ', accounts[0])
-      setCurrentAccount(accounts[0])
+      console.log("Found authorized Account: ", accounts[0]);
+      setCurrentAccount(accounts[0]);
     } else {
-      console.log('No authorized account found')
+      console.log("No authorized account found");
     }
-  }
+  };
 
   // Calls Metamask to connect wallet on clicking Connect Wallet button
   const connectWallet = async () => {
     try {
-      const { ethereum } = window
+      let chainId = await provider.send("eth_chainId");
+      console.log("Connected to chain:" + chainId);
 
-      if (!ethereum) {
-        console.log('Metamask not detected')
-        return
-      }
-      let chainId = await ethereum.request({ method: 'eth_chainId' })
-      console.log('Connected to chain:' + chainId)
+      const rinkebyChainId = "0x4";
 
-      const rinkebyChainId = '0x4'
-
-      const devChainId = 1337
-      const localhostChainId = `0x${Number(devChainId).toString(16)}`
+      const devChainId = 1337;
+      const localhostChainId = `0x${Number(devChainId).toString(16)}`;
 
       if (chainId !== rinkebyChainId && chainId !== localhostChainId) {
-        alert('You are not connected to the Rinkeby Testnet!')
-        return
+        alert("You are not connected to the Rinkeby Testnet!");
+        return;
       }
 
-      const accounts = await ethereum.request({ method: 'eth_requestAccounts' })
+      const accounts = await provider.send({
+        method: "eth_requestAccounts",
+        params: [],
+      });
 
-      console.log('Found account', accounts[0])
-      setCurrentAccount(accounts[0])
+      console.log("Found account", accounts[0]);
+      setCurrentAccount(accounts[0]);
     } catch (error) {
-      console.log('Error connecting to metamask', error)
+      console.log("Error connecting to metamask", error);
     }
-  }
+  };
 
   // Checks if wallet is connected to the correct network
   const checkCorrectNetwork = async () => {
-    const { ethereum } = window
-    let chainId = await ethereum.request({ method: 'eth_chainId' })
-    console.log('Connected to chain:' + chainId)
+    const { ethereum } = window;
+    let chainId = await ethereum.request({ method: "eth_chainId" });
+    console.log("Connected to chain:" + chainId);
 
-    const rinkebyChainId = '0x4'
+    const rinkebyChainId = "0x4";
 
-    const devChainId = 1337
-    const localhostChainId = `0x${Number(devChainId).toString(16)}`
+    const devChainId = 1337;
+    const localhostChainId = `0x${Number(devChainId).toString(16)}`;
 
     if (chainId !== rinkebyChainId && chainId !== localhostChainId) {
-      setCorrectNetwork(false)
+      setCorrectNetwork(false);
     } else {
-      setCorrectNetwork(true)
+      setCorrectNetwork(true);
     }
-  }
+  };
 
   useEffect(() => {
-    checkIfWalletIsConnected()
-    checkCorrectNetwork()
-  }, [])
+    checkIfWalletIsConnected();
+    checkCorrectNetwork();
+  }, []);
 
   // Fetch all signer address list by Sign events
   useEffect(() => {
     const f = async () => {
       try {
-        const { ethereum } = window;
+        const nftContract = new ethers.Contract(
+          nftContractAddress,
+          abi,
+          provider
+        );
 
-        if (ethereum) {
-          const provider = new ethers.providers.Web3Provider(ethereum);
-          const nftContract = new ethers.Contract(
-            nftContractAddress,
-            abi,
-            provider
-          );
-
-          const signEvents = await nftContract.queryFilter("Sign");
-          const signerAddresses = signEvents
-            .sort((a, b) => b.blockNumber - a.blockNumber)
-            .map((e) => e.args.signer);
-          setSignerList(signerAddresses);
-          setSignerListWithENS(
-            signerAddresses.slice(0, SIGNER_AMOUNT_TO_DISPLAY)
-          );
-        } else {
-          console.log("Ethereum object doesn't exist!");
-        }
+        const signEvents = await nftContract.queryFilter("Sign");
+        const signerAddresses = signEvents
+          .sort((a, b) => b.blockNumber - a.blockNumber)
+          .map((e) => e.args.signer);
+        setSignerList(signerAddresses);
+        setSignerListWithENS(
+          signerAddresses.slice(0, SIGNER_AMOUNT_TO_DISPLAY)
+        );
+        // console.log(signerAddresses);
       } catch (error) {
         console.log("Error minting character", error);
         setTxError(error.message);
@@ -131,7 +128,6 @@ const Home = ({data}) => {
 
   // map ens name to signer addresses of first specified amount
   useEffect(() => {
-    const provider = new ethers.providers.Web3Provider(ethereum);
     const f = async () => {
       const nameList = await Promise.all(
         signerList.slice(0, SIGNER_AMOUNT_TO_DISPLAY).map(async (signer) => {
@@ -147,85 +143,66 @@ const Home = ({data}) => {
   // Creates transaction to mint NFT on clicking Mint Character button
   const mintCharacter = async () => {
     try {
-      const { ethereum } = window
+      const signer = provider.getSigner();
+      const nftContract = new ethers.Contract(nftContractAddress, abi, signer);
 
-      if (ethereum) {
-        const provider = new ethers.providers.Web3Provider(ethereum)
-        const signer = provider.getSigner()
-        const nftContract = new ethers.Contract(
-          nftContractAddress,
-          abi,
-          signer
-        )
+      let nftTx = await nftContract.signToStatementAndMintBadge();
+      console.log("Mining....", nftTx.hash);
+      setMiningStatus(0);
 
-        let nftTx = await nftContract.signToStatementAndMintBadge()
-        console.log('Mining....', nftTx.hash)
-        setMiningStatus(0)
+      let tx = await nftTx.wait();
+      setLoadingState(1);
+      console.log("Mined!", tx);
+      let event = tx.events[0];
+      let value = event.args[2];
+      let tokenId = value.toNumber();
 
-        let tx = await nftTx.wait()
-        setLoadingState(1)
-        console.log('Mined!', tx)
-        let event = tx.events[0]
-        let value = event.args[2]
-        let tokenId = value.toNumber()
+      console.log(
+        `Mined, see transaction: https://rinkeby.etherscan.io/tx/${nftTx.hash}`
+      );
 
-        console.log(
-          `Mined, see transaction: https://rinkeby.etherscan.io/tx/${nftTx.hash}`
-        )
-
-        getMintedNFT(tokenId)
-      } else {
-        console.log("Ethereum object doesn't exist!")
-      }
+      getMintedNFT(tokenId);
     } catch (error) {
-      console.log('Error minting character', error)
-      setTxError(error.message)
+      console.log("Error minting character", error);
+      setTxError(error.message);
     }
-  }
+  };
 
   // Gets the minted NFT data
   const getMintedNFT = async (tokenId) => {
     try {
-      const { ethereum } = window
+      const signer = provider.getSigner();
+      const nftContract = new ethers.Contract(nftContractAddress, abi, signer);
 
-      if (ethereum) {
-        const provider = new ethers.providers.Web3Provider(ethereum)
-        const signer = provider.getSigner()
-        const nftContract = new ethers.Contract(
-          nftContractAddress,
-          abi,
-          signer
-        )
+      let tokenUri = await nftContract.tokenURI(tokenId);
+      let data = await axios.get(tokenUri);
+      let meta = data.data;
 
-        let tokenUri = await nftContract.tokenURI(tokenId)
-        let data = await axios.get(tokenUri)
-        let meta = data.data
-
-        setMiningStatus(1)
-        setMintedNFT(meta.image)
-      } else {
-        console.log("Ethereum object doesn't exist!")
-      }
+      setMiningStatus(1);
+      setMintedNFT(meta.image);
     } catch (error) {
-      console.log(error)
-      setTxError(error.message)
+      console.log(error);
+      setTxError(error.message);
     }
-  }
+  };
+
   return (
     <>
       <Head>
-        <title>〈NFTアート〉への共同ステートメント | Community Statement on “NFT art”</title>
-        <meta name='viewport' content='initial-scale=1.0, width=device-width' />
+        <title>
+          〈NFTアート〉への共同ステートメント | Community Statement on “NFT art”
+        </title>
+        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       </Head>
       <Container>
         <Markdown contents={data} />
         <SignContainer>
-          {currentAccount === '' ? (
+          {currentAccount === "" ? (
             <Button onClick={connectWallet}>Connect Wallet</Button>
           ) : correctNetwork ? (
             <Button onClick={mintCharacter}>Sign Statement</Button>
           ) : (
-            <div tw='flex flex-col justify-center items-center mb-20 font-bold text-2xl gap-y-3'>
+            <div tw="flex flex-col justify-center items-center mb-20 font-bold text-2xl gap-y-3">
               <div>----------------------------------------</div>
               <div>Please connect to the Rinkeby Testnet</div>
               <div>and reload the page</div>
@@ -235,17 +212,19 @@ const Home = ({data}) => {
         </SignContainer>
       </Container>
     </>
-  )
-}
+  );
+};
 
 export const getStaticProps = async (context) => {
-  const res = await fetch('https://raw.githubusercontent.com/nft-art-statement/statement/main/statement.md')
-  const text = await res.text()
+  const res = await fetch(
+    "https://raw.githubusercontent.com/nft-art-statement/statement/main/statement.md"
+  );
+  const text = await res.text();
   return {
     props: {
-      data: text
-    }
-  }
-}
+      data: text,
+    },
+  };
+};
 
-export default Home
+export default Home;


### PR DESCRIPTION
#1 の機能追加に加えて下記の変更を加えました。

- https://usedapp.io/ を導入し `window.ethereum` をusedappを利用して接続するように変更
- infuraを利用したproviderに変更

mainnet反映の際は `TODO` で示しているRinkebyでハードコーディングしている部分をmainnetに変更する必要があります。

## usedapp関連の共有事項及びトランザクションのステータス確認方法

usedappを利用して作成したfunctionとstateを記述しています、下記のようになっています。

- `activateBrowserWallet`: 実行することでmetamaskと接続。
- `chainId`: 現在接続しているネットワークのchain id. `ChainId.Rinkeby` などで定数と比較することが可能
- `sign`: コントラクトの `signToStatement` のtxを送信するfunction
- `signState`: `sign`で送信したtxの状態を返却するstate. https://usedapp.readthedocs.io/en/latest/core.html#transactionstatus 記載のステータスに動的に変更される
- `signAndMint`:  `signToStatementAndMintBatch` のtxを送信するfunction
- `signAndMintState`: `signAndMint` で送信したtxの状態を返却するstate. 

また、 `getMintedNFT` は画像を取得しているhooksのようでしたが、画像が固定なのでIPFSに後程アップロードされるURLをハードコーディングする方が良いかなと思い削除させていただきました。　