### PR TITLE
Fix connect button is not shown

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -135,7 +135,7 @@ const Home = ({ data }) => {
           <Leading1>All contents are the same</Leading1>
           <Leading1>No transfer or burn is allowed after the mint</Leading1>
           <SignButtonContainer>
-            {account === undefined ? (
+            {account === undefined || account === null ? (
               <Button onClick={activateBrowserWallet}>Connect Wallet</Button>
             ) : correctNetwork ? (
               <div tw={"flex flex-col justify-center gap-y-6"}>


### PR DESCRIPTION
account接続の検証時にundefinedとの厳密比較が行われているが、未接続の場合に `null` が返却されるため条件に合致されずconnect walletが表示されない状態を修正　

> account - current user account (or null if not connected or connected in read-only mode)
https://usedapp.readthedocs.io/en/latest/guide.html#useethers